### PR TITLE
Fix push/build default booleans

### DIFF
--- a/pkg/models/processor_test.go
+++ b/pkg/models/processor_test.go
@@ -1,0 +1,65 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDefaults_PartialPushConfig(t *testing.T) {
+	p := NewInputProcessor()
+	raw := map[string]interface{}{
+		"container": map[string]interface{}{
+			"push": map[string]interface{}{
+				"onProduction": false,
+			},
+		},
+	}
+
+	inputs, err := p.ProcessInputs(raw)
+	require.NoError(t, err)
+
+	assert.True(t, inputs.Container.Push.Enabled)
+	assert.False(t, inputs.Container.Push.OnProduction)
+}
+
+func TestApplyDefaults_PartialBuildConfig(t *testing.T) {
+	p := NewInputProcessor()
+	raw := map[string]interface{}{
+		"container": map[string]interface{}{
+			"build": map[string]interface{}{
+				"onPR": false,
+			},
+		},
+	}
+
+	inputs, err := p.ProcessInputs(raw)
+	require.NoError(t, err)
+
+	def := DefaultContainerConfig()
+
+	assert.False(t, inputs.Container.Build.OnPR)
+	assert.Equal(t, def.Build.OnProduction, inputs.Container.Build.OnProduction)
+	assert.Equal(t, def.Build.AlwaysBuild, inputs.Container.Build.AlwaysBuild)
+	assert.Equal(t, def.Build.AlwaysPush, inputs.Container.Build.AlwaysPush)
+}
+
+func TestApplyDefaults_DisablePush(t *testing.T) {
+	p := NewInputProcessor()
+	raw := map[string]interface{}{
+		"container": map[string]interface{}{
+			"push": map[string]interface{}{
+				"enabled": false,
+			},
+		},
+	}
+
+	inputs, err := p.ProcessInputs(raw)
+	require.NoError(t, err)
+
+	def := DefaultContainerConfig()
+
+	assert.False(t, inputs.Container.Push.Enabled)
+	assert.Equal(t, def.Push.OnProduction, inputs.Container.Push.OnProduction)
+}


### PR DESCRIPTION
## Summary
- default each boolean field in Push/Build configs individually
- add helper to detect provided input fields
- unit tests for partial push and build configs

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_683f46beb2e8832e844af3f0c60d4215