### PR TITLE
Add python-app template validation

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -74,7 +74,7 @@ type EnvironmentConfig struct {
 var (
 	validAPIVersions = []string{"gpgen.dev/v1"}
 	validKinds       = []string{"Pipeline"}
-	validTemplates   = []string{"node-app", "go-service"}
+	validTemplates   = []string{"node-app", "go-service", "python-app"}
 	positionRegex    = regexp.MustCompile(`^(before|after|replace):[a-z0-9-]+$`)
 )
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -28,6 +28,25 @@ spec:
 	assert.Equal(t, "1.24", manifest.Spec.Inputs["goVersion"])
 }
 
+func TestParseManifest_PythonTemplate(t *testing.T) {
+	yamlContent := `
+apiVersion: gpgen.dev/v1
+kind: Pipeline
+spec:
+  template: "python-app"
+  inputs:
+    pythonVersion: "3.12"
+`
+
+	manifest, err := ParseManifest([]byte(yamlContent))
+	require.NoError(t, err)
+
+	assert.Equal(t, "gpgen.dev/v1", manifest.APIVersion)
+	assert.Equal(t, "Pipeline", manifest.Kind)
+	assert.Equal(t, "python-app", manifest.Spec.Template)
+	assert.Equal(t, "3.12", manifest.Spec.Inputs["pythonVersion"])
+}
+
 func TestParseManifest_ValidComplexManifest(t *testing.T) {
 	yamlContent := `
 apiVersion: gpgen.dev/v1
@@ -192,6 +211,17 @@ func TestValidateManifest_ValidManifests(t *testing.T) {
 							Run:      "echo hello",
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "python template",
+			manifest: &Manifest{
+				APIVersion: "gpgen.dev/v1",
+				Kind:       "Pipeline",
+				Spec: ManifestSpec{
+					Template: "python-app",
+					Inputs:   map[string]interface{}{"pythonVersion": "3.12"},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- include python-app in the list of valid templates
- extend manifest tests with cases for the python template

## Testing
- `go test ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f71195c832eb01ecf89b888654c